### PR TITLE
Refactor selector tablet body class for mobile

### DIFF
--- a/bootstrap/_layout.scss
+++ b/bootstrap/_layout.scss
@@ -10,7 +10,7 @@ body,
 	background-color: $body-bg;
 }
 
-table[class^=body] {
+table.body {
 	@media only screen and (max-width: $layout-width) {
 		.container, #header, #footer,
 		.container > tbody > tr > td.content-inner {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcode-mail-bootstrap",
-  "version": "0.1.14-1",
+  "version": "0.1.15",
   "description": "Default CSS tructure for DcodeMail grunt",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Gmail app consider attribut selector as invalid.
So, it skip a part of style, and display mail on mobile as desktop.